### PR TITLE
add DOCKER_REPOSITORY env; improve indefinite vip handling

### DIFF
--- a/default_config.yml
+++ b/default_config.yml
@@ -42,6 +42,7 @@ player_messages:
   # set to an empty string "" to disable
   reward: "Thank you for helping us seed.\n\nYou've been granted {vip_reward} of VIP\n\nYour VIP currently expires: {vip_expiration}"
   # The message sent to a player after the server has seeded who did not earn VIP
+  # The non_vip message will also be sent to players who have VIP that doesn't expire
   # set to an empty string "" to disable
   non_vip: "Thank you for helping us seed.\n\nThe server is now live and the regular rules apply."
 requirements:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
             - ./logs:/code/logs
             - ./config:/code/config
         restart: unless-stopped
-        image: cericmathey/hll_seed_vip:${DOCKER_TAG}
+        image: ${DOCKER_REPOSITORY}:${DOCKER_TAG}
         build:
           dockerfile: ./Dockerfile

--- a/example.env
+++ b/example.env
@@ -7,6 +7,7 @@ COMPOSE_PROJECT_NAME=
 
 # TRACE DEBUG INFO SUCCESS WARNING ERROR or CRITICAL
 LOG_LEVEL=INFO
+DOCKER_REPOSITORY=cericmathey/hll_seed_vip
 DOCKER_TAG=latest
 
 # The API key of the CRCON account you want to use

--- a/hll_seed_vip/cli.py
+++ b/hll_seed_vip/cli.py
@@ -21,6 +21,7 @@ from hll_seed_vip.utils import (
     message_players,
     reward_players,
     should_announce_seeding_progress,
+    filter_indefinite_vip_steam_ids,
 )
 
 CONFIG_FILE_NAME = os.getenv("CONFIG_FILE_NAME", "config.yml")
@@ -108,6 +109,12 @@ async def main():
                     logger.info(f"Server seeded at {seeded_timestamp.isoformat()}")
                     current_vips = await get_vips(client, config.base_url)
 
+                    # no vip reward needed for indefinite vip holders
+                    indefinite_vip_steam_ids = filter_indefinite_vip_steam_ids(
+                        current_vips
+                    )
+                    to_add_vip_steam_ids -= indefinite_vip_steam_ids
+
                     # Players who were online when we seeded but didn't meet the criteria for VIP
                     no_reward_steam_ids = {
                         p.steam_id_64 for p in online_players.players.values()
@@ -121,12 +128,12 @@ async def main():
                         )
                     )
                     for player in current_vips.values():
-                        expiration_timestamps[
-                            player.player.steam_id_64
-                        ] = calc_vip_expiration_timestamp(
-                            config=config,
-                            expiration=player.expiration_date if player else None,
-                            from_time=seeded_timestamp,
+                        expiration_timestamps[player.player.steam_id_64] = (
+                            calc_vip_expiration_timestamp(
+                                config=config,
+                                expiration=player.expiration_date if player else None,
+                                from_time=seeded_timestamp,
+                            )
                         )
 
                     # Add or update VIP in CRCON

--- a/hll_seed_vip/constants.py
+++ b/hll_seed_vip/constants.py
@@ -1,2 +1,12 @@
+from datetime import datetime, timezone
+from typing import Final
+
 API_KEY = "API_KEY"
 API_KEY_FORMAT = "Bearer: {api_key}"
+
+INDEFINITE_VIP_DATE: Final = datetime(
+    year=3000,
+    month=1,
+    day=1,
+    tzinfo=timezone.utc,
+)

--- a/hll_seed_vip/utils.py
+++ b/hll_seed_vip/utils.py
@@ -27,7 +27,7 @@ from hll_seed_vip.models import (
 from hll_seed_vip.constants import INDEFINITE_VIP_DATE
 
 
-def has_indefinite_vip(player: VipPlayer) -> bool:
+def has_indefinite_vip(player: VipPlayer | None) -> bool:
     """Return true if the player has an indefinite VIP status"""
     if player is None or player.expiration_date is None:
         return False

--- a/hll_seed_vip/utils.py
+++ b/hll_seed_vip/utils.py
@@ -24,7 +24,25 @@ from hll_seed_vip.models import (
     ServerPopulation,
     VipPlayer,
 )
+from hll_seed_vip.constants import INDEFINITE_VIP_DATE
 
+
+def has_indefinite_vip(player: VipPlayer) -> bool:
+    """Return true if the player has an indefinite VIP status"""
+    if player is None or player.expiration_date is None:
+        return False
+    expiration = player.expiration_date
+    return expiration >= INDEFINITE_VIP_DATE
+
+def filter_indefinite_vip_steam_ids(
+    current_vips: dict[str, VipPlayer]
+) -> set[str]:
+    """Return a set of steam IDs that have indefinite VIP status"""
+    return {
+        steam_id_64
+        for steam_id_64, vip_player in current_vips.items()
+        if has_indefinite_vip(vip_player)
+    }
 
 def load_config(path: Path) -> ServerConfig:
     with open(path) as fp:
@@ -262,6 +280,12 @@ async def reward_players(
     for steam_id_64 in to_add_vip_steam_ids:
         player = current_vips.get(steam_id_64)
         expiration_date = expiration_timestamps[steam_id_64]
+
+        if has_indefinite_vip(player):
+            logger.info(
+                f"{config.dry_run=} Skipping! pre-existing indefinite VIP for {steam_id_64=} {player=} {vip_name=} {expiration_date=}"
+            )
+            continue
 
         vip_name = (
             player.player.name

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -9,8 +9,15 @@ from hll_seed_vip.models import (
     PlayerCountCondition,
     ServerConfig,
     ServerPopulation,
+    VipPlayer,
 )
-from hll_seed_vip.utils import all_met, calc_vip_expiration_timestamp, collect_steam_ids
+from hll_seed_vip.utils import (
+    all_met,
+    calc_vip_expiration_timestamp,
+    collect_steam_ids,
+    has_indefinite_vip,
+    filter_indefinite_vip_steam_ids,
+)
 
 
 def make_mock_gamestate(
@@ -35,6 +42,19 @@ def make_mock_player(
         steam_id_64=steam_id_64,
         current_playtime_seconds=current_playertime_seconds,
     )
+
+
+def make_mock_vip_player(steam_id_64: str, expiration_date: datetime | None = None):
+    return VipPlayer(
+        player=make_mock_player(steam_id_64=steam_id_64),
+        expiration_date=expiration_date,
+    )
+
+
+def make_moc_get_vips_dict(vips: list[VipPlayer]) -> dict[str, VipPlayer]:
+    if vips is None:
+        vips = []
+    return {v.player.steam_id_64: v for v in vips}
 
 
 def make_mock_server_pop(players: dict[str, Player] | None = None):
@@ -132,14 +152,16 @@ def test_player_count_conditions(conditions, expected):
         (
             make_mock_config(cumulative_vip=False, vip_reward=timedelta(hours=24)),
             None,
-            datetime.fromisoformat("2023-12-20T22:38:13.780570"),
-            datetime.fromisoformat("2023-12-20T22:38:13.780570") + timedelta(hours=24),
+            datetime.fromisoformat("2023-12-20T22:38:13.780570:00Z"),
+            datetime.fromisoformat("2023-12-20T22:38:13.780570:00Z")
+            + timedelta(hours=24),
         ),
         (
             make_mock_config(cumulative_vip=True, vip_reward=timedelta(hours=24)),
-            datetime.fromisoformat("2023-12-21T22:38:13.780570"),
-            datetime.fromisoformat("2023-12-20T22:38:13.780570"),
-            datetime.fromisoformat("2023-12-21T22:38:13.780570") + timedelta(hours=24),
+            datetime.fromisoformat("2023-12-21T22:38:13.780570:00Z"),
+            datetime.fromisoformat("2023-12-20T22:38:13.780570:00Z"),
+            datetime.fromisoformat("2023-12-21T22:38:13.780570:00Z")
+            + timedelta(hours=24),
         ),
     ],
 )
@@ -155,6 +177,47 @@ def test_cumulative_expirations(
         )
         == expected
     )
+
+
+def test_has_indefinite_vip():
+    vip_player = make_mock_vip_player(steam_id_64="1")
+    assert not has_indefinite_vip(vip_player)
+
+    vip_player = make_mock_vip_player(
+        # this expiration date is in the past
+        steam_id_64="1", expiration_date="2024-01-01T00:00:00Z"
+    )
+    assert not has_indefinite_vip(vip_player)
+
+    vip_player = make_mock_vip_player(
+        steam_id_64="1", expiration_date="3000-01-01T00:00:00Z"
+    )
+    assert has_indefinite_vip(vip_player)
+
+    vip_player = make_mock_vip_player(
+        steam_id_64="1", expiration_date="3333-01-01T00:00:00Z"
+    )
+    assert has_indefinite_vip(vip_player)
+
+
+def test_filter_indefinite_vip_steam_ids():
+    vips = {
+        "1": make_mock_vip_player(
+            # this expiration date is in the past
+            steam_id_64="1", expiration_date="2024-01-01T00:00:00Z"
+        ),
+        "2": make_mock_vip_player(
+            steam_id_64="2", expiration_date="3000-01-01T00:00:00Z"
+        ),
+        "3": make_mock_vip_player(
+            steam_id_64="3", expiration_date="3333-01-01T00:00:00Z"
+        ),
+    }
+
+    assert set(filter_indefinite_vip_steam_ids(vips)) == {"2", "3"}
+
+    vips = {}
+    assert set(filter_indefinite_vip_steam_ids(vips)) == set()
 
 
 def test_collect_steam_ids():

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -191,17 +191,17 @@ def test_has_indefinite_vip():
     vip_player = make_mock_vip_player(
         # this expiration date is in the past
         steam_id_64="1",
-        expiration_date="2024-01-01T00:00:00Z",
+        expiration_date=datetime.fromisoformat("2024-01-01T00:00:00Z"),
     )
     assert not has_indefinite_vip(vip_player)
 
     vip_player = make_mock_vip_player(
-        steam_id_64="1", expiration_date="3000-01-01T00:00:00Z"
+        steam_id_64="1", expiration_date=datetime.fromisoformat("3000-01-01T00:00:00Z")
     )
     assert has_indefinite_vip(vip_player)
 
     vip_player = make_mock_vip_player(
-        steam_id_64="1", expiration_date="3333-01-01T00:00:00Z"
+        steam_id_64="1", expiration_date=datetime.fromisoformat("3333-01-01T00:00:00Z")
     )
     assert has_indefinite_vip(vip_player)
 
@@ -210,9 +210,9 @@ def test_filter_indefinite_vip_steam_ids():
     vips = make_mock_get_vips_dict(
         data={
             # this expiration date is in the past
-            "1": "2024-01-01T00:00:00Z",
-            "2": "3000-01-01T00:00:00Z",
-            "3": "3333-01-01T00:00:00Z",
+            "1": datetime.fromisoformat("2024-01-01T00:00:00Z"),
+            "2": datetime.fromisoformat("3000-01-01T00:00:00Z"),
+            "3": datetime.fromisoformat("3333-01-01T00:00:00Z"),
         }
     )
 

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -51,10 +51,15 @@ def make_mock_vip_player(steam_id_64: str, expiration_date: datetime | None = No
     )
 
 
-def make_moc_get_vips_dict(vips: list[VipPlayer]) -> dict[str, VipPlayer]:
-    if vips is None:
-        vips = []
-    return {v.player.steam_id_64: v for v in vips}
+def make_mock_get_vips_dict(
+    data: dict[str, datetime] | None = None
+) -> dict[str, VipPlayer]:
+    return {
+        steam_id_64: make_mock_vip_player(
+            steam_id_64=steam_id_64, expiration_date=expiration_date
+        )
+        for steam_id_64, expiration_date in (data or {}).items()
+    }
 
 
 def make_mock_server_pop(players: dict[str, Player] | None = None):
@@ -185,7 +190,8 @@ def test_has_indefinite_vip():
 
     vip_player = make_mock_vip_player(
         # this expiration date is in the past
-        steam_id_64="1", expiration_date="2024-01-01T00:00:00Z"
+        steam_id_64="1",
+        expiration_date="2024-01-01T00:00:00Z",
     )
     assert not has_indefinite_vip(vip_player)
 
@@ -201,18 +207,14 @@ def test_has_indefinite_vip():
 
 
 def test_filter_indefinite_vip_steam_ids():
-    vips = {
-        "1": make_mock_vip_player(
+    vips = make_mock_get_vips_dict(
+        data={
             # this expiration date is in the past
-            steam_id_64="1", expiration_date="2024-01-01T00:00:00Z"
-        ),
-        "2": make_mock_vip_player(
-            steam_id_64="2", expiration_date="3000-01-01T00:00:00Z"
-        ),
-        "3": make_mock_vip_player(
-            steam_id_64="3", expiration_date="3333-01-01T00:00:00Z"
-        ),
-    }
+            "1": "2024-01-01T00:00:00Z",
+            "2": "3000-01-01T00:00:00Z",
+            "3": "3333-01-01T00:00:00Z",
+        }
+    )
 
     assert set(filter_indefinite_vip_steam_ids(vips)) == {"2", "3"}
 


### PR DESCRIPTION
Don't add VIP to players with indefinite VIP + send them only the "thanks for seeding message". It might be confusing for people to see their VIP expires in 976 years. :) And it messes up the expiry date.
- add function to filter the VIP players list for indefinite VIPs.
- remove indefinite VIP players from the `to_add_vip_steam_ids` list.
- add unit tests
- add `DOCKER_REPOSITORY` env to make it easier to run a locally built image
- use same ISO datetime format in `test_cumulative_expirations()` that CRCON's `api/get_vip_ids` uses.