### PR TITLE
record version tagging from git describe inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 # syntax=docker/dockerfile:1
+FROM python:3.11-buster as tag_version
+
+WORKDIR /code
+COPY .git/ .git/
+RUN git describe --tags > /code/tag_version
+RUN rm -r .git
+
 FROM python:3.11-slim-buster
 
 ARG APP_NAME=hll_seed_vip
@@ -15,6 +22,7 @@ RUN poetry install --no-root
 
 COPY ./${APP_NAME} ${APP_NAME}
 COPY ./entrypoint.sh entrypoint.sh
+COPY --from=tag_version /code/tag_version /code/tag_version
 
 RUN chmod +x entrypoint.sh
 ENTRYPOINT [ "/code/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 set -e
 set -x
 
+export TAG_VERSION=$(cat /code/tag_version)
+
 if [ ! -d "./config" ]
 then
     echo "Creating config directory"

--- a/hll_seed_vip/cli.py
+++ b/hll_seed_vip/cli.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from itertools import cycle
 from pathlib import Path
+from typing import Final
 
 import discord_webhook as discord
 import httpx
@@ -23,10 +24,11 @@ from hll_seed_vip.utils import (
     should_announce_seeding_progress,
 )
 
-CONFIG_FILE_NAME = os.getenv("CONFIG_FILE_NAME", "config.yml")
-CONFIG_DIR = os.getenv("CONFIG_DIR", "./config")
-LOG_FILE_NAME = os.getenv("LOG_FILE_NAME", "seeding.log")
-LOG_DIR = os.getenv("LOG_DIR", "./logs")
+CONFIG_FILE_NAME: Final = os.getenv("CONFIG_FILE_NAME", "config.yml")
+CONFIG_DIR: Final = os.getenv("CONFIG_DIR", "./config")
+LOG_FILE_NAME: Final = os.getenv("LOG_FILE_NAME", "seeding.log")
+LOG_DIR: Final = os.getenv("LOG_DIR", "./logs")
+TAG_VERSION: Final = os.getenv("TAG_VERSION", "<unknown>")
 
 
 async def raise_on_4xx_5xx(response):
@@ -255,7 +257,7 @@ async def main():
                 else:
                     sleep_time = config.poll_time_seeded
 
-                logger.info(f"sleeping {sleep_time=}")
+                logger.info(f"{TAG_VERSION=} sleeping {sleep_time=}")
                 await trio.sleep(sleep_time)
         except* Exception as eg:
             for e in eg.exceptions:


### PR DESCRIPTION
Embed a version tag (from `git describe --tags`) in the container and emit in the logs:

```
2024-02-09 17:25:06.574 | INFO     | __main__:main:267 - TAG_VERSION='v0.3.0-4-g56352ac' sleeping sleep_time=300
```