### PR TITLE
filter for online vips to reduce spaminess of existing vip message

### DIFF
--- a/hll_seed_vip/cli.py
+++ b/hll_seed_vip/cli.py
@@ -23,6 +23,7 @@ from hll_seed_vip.utils import (
     reward_players,
     should_announce_seeding_progress,
     filter_indefinite_vip_steam_ids,
+    filter_online_players,
 )
 
 CONFIG_FILE_NAME: Final = os.getenv("CONFIG_FILE_NAME", "config.yml")
@@ -110,6 +111,9 @@ async def main():
                     seeded_timestamp = datetime.now(tz=timezone.utc)
                     logger.info(f"Server seeded at {seeded_timestamp.isoformat()}")
                     current_vips = await get_vips(client, config.base_url)
+
+                    # only include online players in the current_vips
+                    current_vips = filter_online_players(current_vips, online_players)
 
                     # no vip reward needed for indefinite vip holders
                     indefinite_vip_steam_ids = filter_indefinite_vip_steam_ids(

--- a/hll_seed_vip/utils.py
+++ b/hll_seed_vip/utils.py
@@ -34,15 +34,26 @@ def has_indefinite_vip(player: VipPlayer | None) -> bool:
     expiration = player.expiration_date
     return expiration >= INDEFINITE_VIP_DATE
 
-def filter_indefinite_vip_steam_ids(
-    current_vips: dict[str, VipPlayer]
-) -> set[str]:
+
+def filter_indefinite_vip_steam_ids(current_vips: dict[str, VipPlayer]) -> set[str]:
     """Return a set of steam IDs that have indefinite VIP status"""
     return {
         steam_id_64
         for steam_id_64, vip_player in current_vips.items()
         if has_indefinite_vip(vip_player)
     }
+
+
+def filter_online_players(
+    vips: dict[str, VipPlayer], players: ServerPopulation
+) -> dict[str, VipPlayer]:
+    """Return a dictionary of players that are online"""
+    return {
+        steam_id_64: vip_player
+        for steam_id_64, vip_player in vips.items()
+        if steam_id_64 in players.players
+    }
+
 
 def load_config(path: Path) -> ServerConfig:
     with open(path) as fp:


### PR DESCRIPTION
Filter the VIP list to only include online players to reduce the verbosity of the `current_vips` log message.